### PR TITLE
docs: Add env defaults for dashboard development

### DIFF
--- a/dashboard/.env.development
+++ b/dashboard/.env.development
@@ -1,1 +1,9 @@
+# required | URL of the tenta server (no trailing slash!)
 NEXT_PUBLIC_SERVER_URL="http://localhost:8421"
+
+# optional | rendered on the login page
+NEXT_PUBLIC_CONTACT_EMAIL="contact.email@login.page"
+
+# optional | rendered in the header
+NEXT_PUBLIC_INSTANCE_TITLE="Your Department Name"
+

--- a/dashboard/.env.template
+++ b/dashboard/.env.template
@@ -7,5 +7,5 @@ NEXT_PUBLIC_SERVER_URL="http://your-server-domain.com"
 NEXT_PUBLIC_CONTACT_EMAIL="contact.email@login.page"
 
 # optional | rendered in the header
-NEXT_PUBLIC_INSTANCE_TITLE="Professorship of Environmental Sensing and Modeling"
+NEXT_PUBLIC_INSTANCE_TITLE="Your Department Name"
 

--- a/docs/pages/contribute.mdx
+++ b/docs/pages/contribute.mdx
@@ -4,6 +4,8 @@ We're very happy about any contributions to Tenta! ✨
 
 ## Development setup
 
+### Server
+
 - Clone the repository and switch into the `server` directory
 - Install the Python version noted in `.python-version` (e.g. with `pyenv`)
 - Install the [poetry package manager](https://github.com/python-poetry/poetry)
@@ -19,9 +21,10 @@ We're very happy about any contributions to Tenta! ✨
 - Have [NodeJS](https://nodejs.org/en) version >= 16 installed on your machine
 - Install the dependencies with `npm install`
 - Start the dashboard in development mode with `npm run dev`; Use the username `happy-un1c0rn` and the password `12345678` to log in
+- You can modify `.env.development` to point your development frontend to a different server
 - The directory structure is explained by [NextJS](https://nextjs.org/) (version 13, app router)
 
-## Documentation
+### Documentation
 
 - Clone the repository and switch into the `docs` directory
 - Have [NodeJS](https://nodejs.org/en) version >= 16 installed on your machine


### PR DESCRIPTION
Thanks for adding these instructions! 😎 I just went through them without prior knowledge and got a bit stuck with how to run the dashboard together with the server.

- Added NextJS [.env.development](https://nextjs.org/docs/app/building-your-application/configuring/environment-variables) file to make the setup a bit easier by defaulting directly to the development server instance; Also added the development credentials
- Reworded the two "Run the development server" to avoid confusion with the "server" name
- Removed production build line as that's already covered in deployment

What do you think?